### PR TITLE
chore: Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Common LaTeX build files
+main.aux
+main.fdb_latexmk
+main.fls
+main.log
+main.pdf
+main.synctex.gz
+indent.log


### PR DESCRIPTION
Adds basic `.gitignore` to avoid committing LaTeX build files.