### PR TITLE
ci: Set up basic CI for compile checks

### DIFF
--- a/.github/workflows/compile-latex.yml
+++ b/.github/workflows/compile-latex.yml
@@ -18,4 +18,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: PDF
-        path: main.pdf
+        path: src/dacs-sw/control-station-installation/main.pdf

--- a/.github/workflows/compile-latex.yml
+++ b/.github/workflows/compile-latex.yml
@@ -17,5 +17,5 @@ jobs:
     - name: Upload PDF file
       uses: actions/upload-artifact@v4
       with:
-        name: PDF
+        name: artifacts
         path: src/dacs-sw/control-station-installation/main.pdf

--- a/.github/workflows/compile-latex.yml
+++ b/.github/workflows/compile-latex.yml
@@ -1,0 +1,21 @@
+name: Build LaTeX document
+on: [push, pull_request]
+
+jobs:
+  build_latex:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Compile LaTeX document
+      uses: xu-cheng/latex-action@v3
+      with:
+        working_directory: src/DACS-SW/DACS-Control-Station-Installation/
+        root_file: main.tex
+        work_in_root_file_dir: true
+
+    - name: Upload PDF file
+      uses: actions/upload-artifact@v4
+      with:
+        name: PDF
+        path: main.pdf

--- a/.github/workflows/compile-latex.yml
+++ b/.github/workflows/compile-latex.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Compile LaTeX document
       uses: xu-cheng/latex-action@v3
       with:
-        working_directory: src/dacs-sw/dacs-control-station-installation/
+        working_directory: src/dacs-sw/control-station-installation/
         root_file: main.tex
         work_in_root_file_dir: true
 

--- a/.github/workflows/compile-latex.yml
+++ b/.github/workflows/compile-latex.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Compile LaTeX document
       uses: xu-cheng/latex-action@v3
       with:
-        working_directory: src/DACS-SW/DACS-Control-Station-Installation/
+        working_directory: src/dacs-sw/dacs-control-station-installation/
         root_file: main.tex
         work_in_root_file_dir: true
 


### PR DESCRIPTION
Compiles the LaTeX doc and uploads the resulting artifact.

Right now this is only set up for a single LaTeX project. The long term goal is to have it recursively discover projects and compile all of them on every run.