### PR TITLE
ci: Prevent `tagpr` from creating a release

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -40,3 +40,4 @@
 	vPrefix = true
 	releaseBranch = main
 	versionFile = -
+	release = false


### PR DESCRIPTION
We use `softprops/action-gh-release@v2` to take care of making the release