### PR TITLE
chore(ci): Update `actions/checkout` to v4

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -7,7 +7,7 @@ jobs:
   tagpr:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: Songmu/tagpr@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The copied example config still used the deprecated v3