### PR TITLE
ci: Trigger on release instead of tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: "Make release"
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [ created ]
 
 permissions:
   contents: write # Needed to write to GitHub draft release


### PR DESCRIPTION
Triggering from tag pushed from CI does not work as GitHub blocks it to prevent infinitely running actions or accidental retriggers.