### PR TITLE
ci: Manually specify which tag `softprops/action-gh-release` should use

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -25,5 +25,6 @@ jobs:
       if: ${{ steps.tagpr.outputs.tag != '' }}
       uses: softprops/action-gh-release@v2
       with:
+        tag_name: ${{ steps.tagpr.outputs.tag }}
         files: |
           src/dacs-sw/control-station-installation/main.pdf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## [v0.0.6](https://github.com/aris-space/helios-procedures/compare/v0.0.5...v0.0.6) - 2024-05-03
-- ci: Use tagpr output to trigger release by @tgeorg-ethz in https://github.com/aris-space/helios-procedures/pull/17
-
 ## [v0.0.4](https://github.com/aris-space/helios-procedures/compare/v0.0.3...v0.0.4) - 2024-05-03
 - ci: Make release draft by @tgeorg-ethz in https://github.com/aris-space/helios-procedures/pull/15
 


### PR DESCRIPTION
Otherwise the action will fail as it was not triggered by a tag but by a push.