### PR TITLE
ci: Compile all procedures in a single step

### DIFF
--- a/.github/workflows/compile-latex.yml
+++ b/.github/workflows/compile-latex.yml
@@ -7,35 +7,23 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Compile LaTeX document
-      uses: xu-cheng/latex-action@v3
-      with:
-        working_directory: src/dacs-sw/control-station-installation/
-        root_file: main.tex
-        work_in_root_file_dir: true
+    - name: Compile all LaTeX documents
+      run: |
+        projects=("control-station-installation" "template" "database-ingestion")
+        for project in "${projects[@]}"; do
+          working_directory="src/dacs-sw/$project"
+          root_file="main.tex"
+          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace/$working_directory texlive/texlive:latest latexmk -pdf -interaction=nonstopmode $root_file
+        done
 
-    - name: Compile LaTeX template document
-      uses: xu-cheng/latex-action@v3
-      with:
-        working_directory: src/dacs-sw/template/
-        root_file: main.tex
-        work_in_root_file_dir: true
-
-    - name: Compile LaTeX data ingestion document
-      uses: xu-cheng/latex-action@v3
-      with:
-        working_directory: src/dacs-sw/database-ingestion/
-        root_file: main.tex
-        work_in_root_file_dir: true
-      
     - name: Rename files and move to single release folder
       run: |
-        mkdir release
+        mkdir --parents release
         mv src/dacs-sw/control-station-installation/main.pdf release/dacs-sw-control-station-installation.pdf
         mv src/dacs-sw/template/main.pdf release/dacs-sw-template.pdf
         mv src/dacs-sw/database-ingestion/main.pdf release/dacs-sw-database-ingestion.pdf
 
-    - name: Upload PDF file
+    - name: Upload PDF files
       uses: actions/upload-artifact@v4
       with:
         name: artifacts

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -19,29 +19,15 @@ jobs:
       run: |
         sed -i 's/\\setboolean{isDraft}{true}/\\setboolean{isDraft}{false}/' src/dacs-sw/control-station-installation/main.tex
 
-    - name: Compile LaTeX document
+    - name: Compile all LaTeX documents
       if: ${{ steps.tagpr.outputs.tag != '' }}
-      uses: xu-cheng/latex-action@v3
-      with:
-        working_directory: src/dacs-sw/control-station-installation/
-        root_file: main.tex
-        work_in_root_file_dir: true
-
-    - name: Compile LaTeX template document
-      if: ${{ steps.tagpr.outputs.tag != '' }}
-      uses: xu-cheng/latex-action@v3
-      with:
-        working_directory: src/dacs-sw/template/
-        root_file: main.tex
-        work_in_root_file_dir: true
-
-    - name: Compile LaTeX database ingestion document
-      if: ${{ steps.tagpr.outputs.tag != '' }}
-      uses: xu-cheng/latex-action@v3
-      with:
-        working_directory: src/dacs-sw/database-ingestion/
-        root_file: main.tex
-        work_in_root_file_dir: true
+      run: |
+        projects=("control-station-installation" "template" "database-ingestion")
+        for project in "${projects[@]}"; do
+          working_directory="src/dacs-sw/$project"
+          root_file="main.tex"
+          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace/$working_directory texlive/texlive:latest latexmk -pdf -interaction=nonstopmode $root_file
+        done
 
     - name: Rename files and move to single release folder
       if: ${{ steps.tagpr.outputs.tag != '' }}


### PR DESCRIPTION
Instead of adding a CI step for every procedure, have a single step that compiles all procedures.
This implementation is a bit messy as it pulls a Docker image and then runs the compilation in there but it should suffice for now until improved again later.