### PR TITLE
ci: Create parent folder if not exists

### DIFF
--- a/.github/workflows/compile-latex.yml
+++ b/.github/workflows/compile-latex.yml
@@ -30,7 +30,7 @@ jobs:
       
     - name: Rename files and move to single release folder
       run: |
-        mkdir release
+        mkdir --parents release
         mv src/dacs-sw/control-station-installation/main.pdf release/dacs-sw-control-station-installation.pdf
         mv src/dacs-sw/template/main.pdf release/dacs-sw-template.pdf
         mv src/dacs-sw/database-ingestion/main.pdf release/dacs-sw-database-ingestion.pdf

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Rename files and move to single release folder
       if: ${{ steps.tagpr.outputs.tag != '' }}
       run: |
-        mkdir release
+        mkdir --parents release
         mv src/dacs-sw/control-station-installation/main.pdf release/dacs-sw-control-station-installation.pdf
         mv src/dacs-sw/template/main.pdf release/dacs-sw-template.pdf
         mv src/dacs-sw/database-ingestion/main.pdf release/dacs-sw-database-ingestion.pdf


### PR DESCRIPTION
Basically, do `mkdir --parents release` instead of `mkdir release` to create parent folders if they don't exist.