### PR TITLE
chore: Fix typo in CI step name

### DIFF
--- a/.github/workflows/compile-latex.yml
+++ b/.github/workflows/compile-latex.yml
@@ -35,7 +35,7 @@ jobs:
         mv src/dacs-sw/template/main.pdf release/dacs-sw-template.pdf
         mv src/dacs-sw/database-ingestion/main.pdf release/dacs-sw-database-ingestion.pdf
 
-    - name: Upload PDF file
+    - name: Upload PDF files
       uses: actions/upload-artifact@v4
       with:
         name: artifacts


### PR DESCRIPTION
"_Upload PDF file**s**_" instead of "_Upload PDF file_"