### PR TITLE
fix(ci): Do not show draft watermark on release files

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -17,7 +17,7 @@ jobs:
       if: ${{ steps.tagpr.outputs.tag != '' }}
       # Set the variable controlling the watermark addition to `false`
       run: |
-        sed -i 's/\\setboolean{isDraft}{true}/\\setboolean{isDraft}{false}/' src/dacs-sw/control-station-installation/main.tex
+        sed -i 's/\\setboolean{isDraft}{true}/\\setboolean{isDraft}{false}/' src/common/lib/header.tex
 
     - name: Compile all LaTeX documents
       if: ${{ steps.tagpr.outputs.tag != '' }}


### PR DESCRIPTION
The CI config wasn't updated when some stuff was moved to common library files.