### PR TITLE
ci: Use Python script to move compiled LaTeX files

### DIFF
--- a/.github/workflows/compile-latex.yml
+++ b/.github/workflows/compile-latex.yml
@@ -19,9 +19,7 @@ jobs:
     - name: Rename files and move to single release folder
       run: |
         mkdir --parents release
-        mv src/dacs-sw/control-station-installation/main.pdf release/dacs-sw-control-station-installation.pdf
-        mv src/dacs-sw/template/main.pdf release/dacs-sw-template.pdf
-        mv src/dacs-sw/database-ingestion/main.pdf release/dacs-sw-database-ingestion.pdf
+        python3 scripts/move-files.py
 
     - name: Upload PDF files
       uses: actions/upload-artifact@v4

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -33,9 +33,7 @@ jobs:
       if: ${{ steps.tagpr.outputs.tag != '' }}
       run: |
         mkdir --parents release
-        mv src/dacs-sw/control-station-installation/main.pdf release/dacs-sw-control-station-installation.pdf
-        mv src/dacs-sw/template/main.pdf release/dacs-sw-template.pdf
-        mv src/dacs-sw/database-ingestion/main.pdf release/dacs-sw-database-ingestion.pdf
+        python3 scripts/move-files.py
 
     - name: Make release with PDFs
       if: ${{ steps.tagpr.outputs.tag != '' }}

--- a/scripts/move-files.py
+++ b/scripts/move-files.py
@@ -21,8 +21,11 @@ for root, dirs, files in os.walk(base_folder):
         old_path = os.path.join(root, file)
 
         # Create the new file name with '-' instead of '/'
-        relative_path = os.path.relpath(old_path, base_folder)
+        relative_path = os.path.relpath(root, base_folder)
         new_filename = relative_path.replace(os.sep, "-")
+
+        # Add the '.pdf' extension to the new filename
+        new_filename += ".pdf"
 
         # Construct the new file path
         new_path = os.path.join(release_folder, new_filename)

--- a/scripts/move-files.py
+++ b/scripts/move-files.py
@@ -1,0 +1,32 @@
+import os
+import shutil
+
+
+# Define folders
+base_folder = "src"
+release_folder = "release"
+
+# Ensure the release folder exists
+if not os.path.exists(release_folder):
+    os.makedirs(release_folder)
+
+# Go through all subdirectories
+for root, dirs, files in os.walk(base_folder):
+    for file in files:
+        if file != "main.pdf":
+            # Skip file if it's not `main.pdf`
+            continue
+
+        # Construct the original file path
+        old_path = os.path.join(root, file)
+
+        # Create the new file name with '-' instead of '/'
+        relative_path = os.path.relpath(old_path, base_folder)
+        new_filename = relative_path.replace(os.sep, "-")
+
+        # Construct the new file path
+        new_path = os.path.join(release_folder, new_filename)
+
+        # Move and rename the file
+        shutil.move(old_path, new_path)
+        print(f"Moved {old_path} to {new_path}")


### PR DESCRIPTION
Moves all created PDFs to `release` folder instead of manually specifying each one in the YAML config file.