### PR TITLE
ci: Discover and compile LaTeX files recursively

### DIFF
--- a/.github/workflows/compile-latex.yml
+++ b/.github/workflows/compile-latex.yml
@@ -8,13 +8,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Compile all LaTeX documents
-      run: |
-        projects=("control-station-installation" "template" "database-ingestion")
-        for project in "${projects[@]}"; do
-          working_directory="src/dacs-sw/$project"
-          root_file="main.tex"
-          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace/$working_directory texlive/texlive:latest latexmk -pdf -interaction=nonstopmode $root_file
-        done
+      run: python3 scripts/compile_latex.py
 
     - name: Rename files and move to single release folder
       run: |

--- a/.github/workflows/compile-latex.yml
+++ b/.github/workflows/compile-latex.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Compile all LaTeX documents
-      run: python3 scripts/compile_latex.py
+      run: python3 scripts/compile-all-latex.py
 
     - name: Rename files and move to single release folder
       run: |

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -21,13 +21,7 @@ jobs:
 
     - name: Compile all LaTeX documents
       if: ${{ steps.tagpr.outputs.tag != '' }}
-      run: |
-        projects=("control-station-installation" "template" "database-ingestion")
-        for project in "${projects[@]}"; do
-          working_directory="src/dacs-sw/$project"
-          root_file="main.tex"
-          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace/$working_directory texlive/texlive:latest latexmk -pdf -interaction=nonstopmode $root_file
-        done
+      run: python3 scripts/compile_latex.py
 
     - name: Rename files and move to single release folder
       if: ${{ steps.tagpr.outputs.tag != '' }}

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Compile all LaTeX documents
       if: ${{ steps.tagpr.outputs.tag != '' }}
-      run: python3 scripts/compile_latex.py
+      run: python3 scripts/compile-all-latex.py
 
     - name: Rename files and move to single release folder
       if: ${{ steps.tagpr.outputs.tag != '' }}

--- a/scripts/compile-all-latex.py
+++ b/scripts/compile-all-latex.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+
+projects = ["control-station-installation", "template", "database-ingestion"]
+
+for project in projects:
+    working_directory = f"src/dacs-sw/{project}"
+    root_file = "main.tex"
+    command = [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{os.environ['GITHUB_WORKSPACE']}:/workspace",
+        "-w",
+        f"/workspace/{working_directory}",
+        "texlive/texlive:latest",
+        "latexmk",
+        "-pdf",
+        "-interaction=nonstopmode",
+        root_file,
+    ]
+    subprocess.run(command, check=True)

--- a/scripts/compile-all-latex.py
+++ b/scripts/compile-all-latex.py
@@ -1,11 +1,18 @@
 import os
 import subprocess
 
-projects = ["control-station-installation", "template", "database-ingestion"]
+# Define folders and files
+base_folder = "src"
+root_file = "main.tex"
 
-for project in projects:
-    working_directory = f"src/dacs-sw/{project}"
-    root_file = "main.tex"
+
+# Go through all subdirectories
+for dirpath, _, filenames in os.walk(base_folder):
+    if not root_file in filenames:
+        # Skip if there's no `main.tex`
+        continue
+    
+    # Compile LaTeX
     command = [
         "docker",
         "run",
@@ -13,11 +20,11 @@ for project in projects:
         "-v",
         f"{os.environ['GITHUB_WORKSPACE']}:/workspace",
         "-w",
-        f"/workspace/{working_directory}",
+        f"/workspace/{dirpath}",
         "texlive/texlive:latest",
         "latexmk",
         "-pdf",
         "-interaction=nonstopmode",
-        root_file,
+        f"{root_file}",
     ]
     subprocess.run(command, check=True)


### PR DESCRIPTION
Instead of manually specifying which procedures to compile, search for all `main.tex` and compile those.

This way, we can add more procedures without having to add each one to the CI YAML config.