### PR TITLE
feat: Add table counter to template

### DIFF
--- a/src/dacs-sw/template/main.tex
+++ b/src/dacs-sw/template/main.tex
@@ -7,6 +7,9 @@
 % Initialize counter
 \setcounter{rowCounter}{0}
 
+\newcounter{tableCounter}
+\setcounter{tableCounter}{0}
+
 % Command for row in checklist
 % First argument is amount
 % Second argument is description
@@ -17,7 +20,7 @@
 % Command for row in procedure list
 \newcommand{\procedureItem}[1]{
   \stepcounter{rowCounter} % Increment counter
-  1.\arabic{rowCounter}
+  \arabic{tableCounter}.\arabic{rowCounter}
   &
   \checkbox
   &

--- a/src/dacs-sw/template/sections/installation.tex
+++ b/src/dacs-sw/template/sections/installation.tex
@@ -1,5 +1,6 @@
 % Procedure for installation
 
+\stepcounter{tableCounter} % Increment counter
 \setcounter{rowCounter}{0} % Reset counter
 \begin{tabularx}{\textwidth}{|>{\columncolor{tableColumnColor}}c|>{\columncolor{tableColumnColor}}c|>{\columncolor{tableColumnColor}}c|>{\columncolor{tableColumnColor}}c|X|}
   \hline


### PR DESCRIPTION
Counter is used to specify the table in the current step. Was previously hardcoded.

Already used in the data ingestion procedure.