### PR TITLE
feat: Add `dvipsnames` to the xcolor imports

### DIFF
--- a/src/common/lib/header.tex
+++ b/src/common/lib/header.tex
@@ -18,7 +18,7 @@
 \newdateformat{isodate}{\THEYEAR-\twodigit{\THEMONTH}-\twodigit{\THEDAY}}
 
 % Table colouring
-\usepackage[table]{xcolor}
+\usepackage[table,dvipsnames]{xcolor}
 \definecolor{tableHeaderColor}
 {rgb}{0.75,0.75,0.75}
 \definecolor{tableColumnColor}


### PR DESCRIPTION
Allows specifying colours by name