### PR TITLE
feat(docs): Mention taking picture of UI after installation

### DIFF
--- a/src/dacs-sw/control-station-installation/sections/installation.tex
+++ b/src/dacs-sw/control-station-installation/sections/installation.tex
@@ -172,6 +172,12 @@
   }
 
   \procedureItem{
+    (for 2024-06-29 firing only)
+  \\
+    Take picture of UI while system is still de-pressurised and set to Anna Möri to confirm that offsets have not changed.
+  }
+
+  \procedureItem{
     Confirm that you get a live camera feed.
   }
 


### PR DESCRIPTION
Mention taking picture of UI after installation while system is still depressurised in order to compare offsets to previous measurements as requested by Anna.