### PR TITLE
Rename all occurences to "HELIOS Ethernet Switch"

### DIFF
--- a/src/dacs-sw/control-station-installation/sections/installation.tex
+++ b/src/dacs-sw/control-station-installation/sections/installation.tex
@@ -31,15 +31,15 @@
   }
 
   \procedureItem{
-    Connect 100m Ethernet cable to PRO Ethernet Switch
+    Connect 100m Ethernet cable to HELIOS Ethernet Switch
   }
 
   \procedureItem{
-    Connect PRO Ethernet switch to PRO Mission Control PC with short Ethernet cable
+    Connect HELIOS Ethernet Switch to PRO Mission Control PC with short Ethernet cable
   }
 
   \procedureItem{
-    Connect PRO Ethernet switch to KiDAQ PC with short Ethernet cable
+    Connect HELIOS Ethernet Switch to KiDAQ PC with short Ethernet cable
   }
 
   \procedureItem{

--- a/src/dacs-sw/control-station-installation/sections/required-tools.tex
+++ b/src/dacs-sw/control-station-installation/sections/required-tools.tex
@@ -16,6 +16,6 @@
   \checklistItem{3}{DP Cable}
   \checklistItem{1}{Phone with Hotspot \& Charger}
   \checklistItem{1}{Ethernet cable on cable roll (connected to testbench)}
-  \checklistItem{1}{PRO Ethernet Switch with power cable}
+  \checklistItem{1}{HELIOS Ethernet Switch with power cable}
   \checklistItem{2}{Short Ethernet cable}
 \end{tabularx}

--- a/src/dacs-sw/control-station-preparation/sections/required-tools.tex
+++ b/src/dacs-sw/control-station-preparation/sections/required-tools.tex
@@ -16,6 +16,6 @@
   \checklistItem{3}{DP Cable}
   \checklistItem{1}{Phone with Hotspot \& Charger}
   \checklistItem{1}{Ethernet cable on cable roll (connected to testbench)}
-  \checklistItem{1}{PRO Ethernet Switch with power cable}
+  \checklistItem{1}{HELIOS Ethernet Switch with power cable}
   \checklistItem{2}{Short Ethernet cable}
 \end{tabularx}

--- a/src/dacs-sw/data-saving-and-export/sections/required-tools.tex
+++ b/src/dacs-sw/data-saving-and-export/sections/required-tools.tex
@@ -14,6 +14,6 @@
   \checklistItem{2}{DP Cable}
   \checklistItem{1}{Phone with Hotspot \& Charger}
   \checklistItem{1}{Ethernet cable on cable roll (connected to test bench)}
-  \checklistItem{1}{PRO Ethernet Switch with power cable}
+  \checklistItem{1}{HELIOS Ethernet Switch with power cable}
   \checklistItem{1}{Short Ethernet cable}
 \end{tabularx}


### PR DESCRIPTION
Rename all occurences to "HELIOS Ethernet Switch" from "PRO Ethernet Switch"

The corresponding device was replaced in the firing of 2024-06-22