### PR TITLE
Adjust config file related steps

### DIFF
--- a/src/dacs-sw/control-station-deinstallation/sections/deinstallation.tex
+++ b/src/dacs-sw/control-station-deinstallation/sections/deinstallation.tex
@@ -12,6 +12,22 @@
   }
 
   \procedureItem{
+    Upload the config file from the MCPC to Sharepoint.
+
+    \begin{itemize}
+      \item On the MCPC it is located at
+            \\
+            \texttt{/home/dacs/git/configuration-tests/PRO\_DACS-Configuration.xlsx}
+
+      \item On Sharepoint it should be uploaded to
+            \\
+            \texttt{03\_Projects -> 2024\_HELIOS\_Liquid Rocket Engine -> 08 DACS -> Config files -> PRO\_DACS-Configuration.xlsx}
+            \\
+            \textbf{overriding} the previous version on Sharepoint.
+    \end{itemize}
+  }
+
+  \procedureItem{
     Unplug the power supply of the trailer and roll cable up onto cable roll
   }
 

--- a/src/dacs-sw/control-station-installation/sections/installation.tex
+++ b/src/dacs-sw/control-station-installation/sections/installation.tex
@@ -71,7 +71,14 @@
   }
 
   \procedureItem{
-    Grab newest config file from sharepoint
+    Check the \texttt{\#helios-config-file} Slack channel if any recent changes have been made to the config file.
+  \\
+    \noindent
+  \\
+    In case there have been changes that are not on the MCPC, figure out how to proceed.
+    The changes from Sharepoint may not have been tested.
+  \\
+    When in doubt, use the version from the MCPC and inform the author who made the changes that are not on the MCPC that their change has been ignored and will be reverted at the end of the test.
   }
 
   \procedureItem{


### PR DESCRIPTION
Adjust config file related steps based on the decision to make the MCPC the ground truth

In particular:

- If there's a difference with Sharepoint, prefer version on MCPC
- After test, make sure to upload config file to Sharepoint
