### PR TITLE
Remove one-time entry to take a screenshot of the depressurised system

### DIFF
--- a/src/dacs-sw/control-station-installation/sections/installation.tex
+++ b/src/dacs-sw/control-station-installation/sections/installation.tex
@@ -184,11 +184,11 @@
     Confirm that you get valid data read outs from the trailer.
   }
 
-  \procedureItem{
-    (for 2024-06-29 firing only)
-  \\
-    Take picture of UI while system is still de-pressurised and set to Anna Möri to confirm that offsets have not changed.
-  }
+  % \procedureItem{
+  %   (for 2024-06-29 firing only)
+  % \\
+  %   Take picture of UI while system is still de-pressurised and set to Anna Möri to confirm that offsets have not changed.
+  % }
 
   \procedureItem{
     Confirm that you get a live camera feed.


### PR DESCRIPTION
Remove one-time entry to take a screenshot of the depressurised system from installation procedure.